### PR TITLE
Restore the magic w/o stomping on your other changes

### DIFF
--- a/src/functions/public/ConvertTo-WebQueryString.ps1
+++ b/src/functions/public/ConvertTo-WebQueryString.ps1
@@ -1,45 +1,33 @@
 ﻿function ConvertTo-WebQueryString {
     <#
-        .SYNOPSIS
+    .SYNOPSIS
         Converts a hashtable or NameValueCollection into a web query string.
 
-        .DESCRIPTION
+    .DESCRIPTION
         This function takes an IDictionary object (such as a hashtable) or a NameValueCollection
-        and converts it into a properly formatted query string. By default, spaces in values
-        are encoded as `%20`. If the `-AsURLEncoded` switch is provided, spaces are encoded as `+`.
+        and converts it into a properly formatted query string.
 
         The function supports multiple values for the same key, ensuring compatibility with
         APIs and web services that expect repeated keys.
+	
+    .PARAMETER InputObject
+        IDictionary, HttpQSCollection, or NameValueCollection Object to be converted.
 
-        .EXAMPLE
-        @{ taco = 12; burrito = 8; quesadilla = 6 } | ConvertTo-WebQueryString
+    .EXAMPLE
+        @{ taco = 12;burrito = 8;quesadilla = 6 } | ConvertTo-WebQueryString
         ----
         taco=12&quesadilla=6&burrito=8
 
         Converts a hashtable into a query string where key-value pairs are joined using `&`.
 
-        .EXAMPLE
-        ConvertTo-WebQueryString -InputObject @{a='this is value of a'; b='valueOfB'}
-        ----
-        a=this%20is%20value%20of%20a&b=valueOfB
-
-        Converts a hashtable where values contain spaces. The default encoding uses `%20` for spaces.
-
-        .EXAMPLE
-        ConvertTo-WebQueryString -InputObject @{a='this is value of a'; b='valueOfB'} -AsURLEncoded
-        ----
-        a=this+is+value+of+a&b=valueOfB
-
-        Converts a hashtable while using `+` for spaces, which is preferred in some URL encoding schemes.
-
-        .EXAMPLE
-        @{ state = 'OPEN' }, @{ state = 'MERGED' } | ConvertTo-WebQueryString
+    .EXAMPLE
+        @{ state = 'OPEN' },@{ state = 'MERGED' } | ConvertTo-WebQueryString
         ----
         state=OPEN&state=MERGED
 
         Converts multiple objects with the same key into a properly formatted query string.
 
-        .EXAMPLE
+    .EXAMPLE
         $collection = [System.Web.HttpUtility]::ParseQueryString([string]::Empty)
         $collection.Add('pagelen', 50)
         $collection.Add('state', 'OPEN')
@@ -50,23 +38,26 @@
 
         Converts a `NameValueCollection` into a query string, preserving multiple values for a key.
 
-        .EXAMPLE
+    .EXAMPLE
         $collection = [System.Web.HttpUtility]::ParseQueryString([string]::Empty)
         $collection.Add('pagelen', 50)
         $collection.Add('state', 'OPEN')
         $collection.Add('state', 'MERGED')
         $collection.Add('q', 'created_on>=2024-01-25T16:37:56Z')
-        # The leading comma below is significant. Without it, only the array of key strings
+        # The leading comma below is significant.  Without it, only the array of key strings
         # are piped to ConvertTo-WebQueryString which will output $null as a result.
         ,$collection | ConvertTo-WebQueryString
         ----
-        pagelen=50&state=OPEN&state=MERGED&q=created_on%3E%3D2024-01-25T16%3A37%3A56Z
+        pagelen=50&state=OPEN&state=MERGED&q=created_on%3e%3d2024-01-25T16%3a37%3a56Z
 
         Converts a NameValueCollection containing special characters. The percent encoding triplet
         is normalized to uppercase according to [RFC 3986 6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).
 
         .LINK
         https://psmodule.io/Web/Functions/ConvertTo-WebQueryString/
+	
+        .LINK
+        https://referencesource.microsoft.com/#system.web/HttpQSCollection.cs
     #>
     [CmdletBinding()]
     param(
@@ -74,46 +65,23 @@
         # Accepts IDictionary, HttpQSCollection, or NameValueCollection objects.
         [Parameter(
             Mandatory,
+	    Position = 0, # This allows the syntax: ConvertTo-WebQueryString @{ n = 'v' }
             ValueFromPipeline
         )]
-        [object] $InputObject,
-
-        # If specified, uses the URL encoding from [System.Web.HttpUtility]::UrlEncode which uses + for spaces.
-        # Otherwise, [System.Uri]::EscapeDataString is used, which produces %20 for spaces.
-        [Parameter()]
-        [switch] $AsURLEncoded
+        [object] $InputObject
     )
 
     begin {
-        $encodedPairs = @()
+        # This creates an empty HttpQSCollection which provides the magic .ToString method
+        $collection = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
     }
 
     process {
         if ($InputObject -is [System.Collections.Specialized.NameValueCollection]) {
-            foreach ($key in $InputObject.AllKeys) {
-                $values = $InputObject.GetValues($key)
-                foreach ($value in $values) {
-                    if ($AsURLEncoded) {
-                        $encodedKey = [System.Web.HttpUtility]::UrlEncode($key)
-                        $encodedValue = [System.Web.HttpUtility]::UrlEncode($value)
-                    } else {
-                        $encodedKey = [System.Uri]::EscapeDataString($key)
-                        $encodedValue = [System.Uri]::EscapeDataString($value)
-                    }
-                    $encodedPairs += "$encodedKey=$encodedValue"
-                }
-            }
+            $collection.Add($InputObject)
         } elseif ($InputObject -is [System.Collections.IDictionary]) {
             foreach ($key in $InputObject.Keys) {
-                $value = $InputObject[$key]
-                if ($AsURLEncoded) {
-                    $encodedKey = [System.Web.HttpUtility]::UrlEncode($key)
-                    $encodedValue = [System.Web.HttpUtility]::UrlEncode($value)
-                } else {
-                    $encodedKey = [System.Uri]::EscapeDataString($key)
-                    $encodedValue = [System.Uri]::EscapeDataString($value)
-                }
-                $encodedPairs += "$encodedKey=$encodedValue"
+                $collection.Add($key, $InputObject.$Key)
             }
         } else {
             throw "InputObject type not supported: $($InputObject.GetType())"
@@ -121,6 +89,6 @@
     }
 
     end {
-        $encodedPairs -join '&'
+        $collection.ToString()
     }
 }


### PR DESCRIPTION
## Description

If you insist on `%20`, that can be achieved using -replace like so: `$collection.ToString() -replace '\+','%20'`

However, if you do, I'd very much like to know what endpoints require it so I can justify changing my own implementation elsewhere.

## Type of change

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
